### PR TITLE
Fixes nested wiki-links

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -19,7 +19,13 @@ module.exports = (eleventyConfig) => {
       const isRelative = isRelativePattern.test(link);
 
       if (isRelative) {
-        return env.page.url.replace(lastSegmentPattern, link);
+        const hasLastSegment = lastSegmentPattern.exec(env.page.url);
+        // If it's nested, replace the last segment
+        if (hasLastSegment) {
+          return env.page.url.replace(lastSegmentPattern, link);
+        }
+        // If it's at root, just add the beginning slash
+        return env.page.url + link;
       }
 
       return link;

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,18 +1,47 @@
 module.exports = (eleventyConfig) => {
+  eleventyConfig.addPassthroughCopy(".htaccess");
+  eleventyConfig.addTransform("wiki-links", function (content, outputPath) {
+    if (outputPath.endsWith(".html")) {
+      // We remove outer brackets from links
+      let output = content.replace(/(\[+(\<a(.*?)\<\/a\>)\]+)/g, "$2");
+      return output;
+    }
+    return content;
+  });
+
+  let markdownIt = require("markdown-it");
+  let markdownItReplaceLink = require("markdown-it-replace-link");
+  let markdownItOptions = {
+    html: true,
+    replaceLink: function (link, env) {
+      const isRelativePattern = /^(?!http|\/).*/;
+      const lastSegmentPattern = /[^\/]+(?=\/$|$)/i;
+      const isRelative = isRelativePattern.test(link);
+
+      if (isRelative) {
+        return env.page.url.replace(lastSegmentPattern, link);
+      }
+
+      return link;
+    },
+  };
+  let markdownLib = markdownIt(markdownItOptions).use(markdownItReplaceLink);
+  eleventyConfig.setLibrary("md", markdownLib);
 
   return {
     dir: {
       input: ".",
       output: "_site",
       includes: "_includes",
-      layouts: "_layouts"
+      layouts: "_layouts",
     },
     templateFormats: [
+      //
       "js",
       "md",
       "html",
-      "liquid"
+      "liquid",
     ],
-    passthroughFileCopy: true
+    passthroughFileCopy: true,
   };
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "devDependencies": {
     "@11ty/eleventy": "^0.11.0",
     "clean-css": "4.2.3",
+    "markdown-it": "11.0.0",
+    "markdown-it-replace-link": "1.1.0",
     "node-sass-promise": "1.0.0"
   }
 }


### PR DESCRIPTION
fixes #4

I don't know if this is the best solution, but it's working for now.

This removes the extra bracket from wiki links:

```html
From this:
[<a href="todo" title="Todo">todo</a>]
To this:
<a href="todo" title="Todo">todo</a>
```

And takes links that doesn't start with `http` or `/` adds the full path from root:

`todo` gets transformed into `/bubbles/todo/`

